### PR TITLE
Disable hard reset when server goes down

### DIFF
--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -496,7 +496,7 @@ LifecycleManager::checkBondConnections()
         "CRITICAL FAILURE: SERVER %s IS DOWN after not receiving a heartbeat for %i ms."
         " Shutting down related nodes.",
         node_name.c_str(), static_cast<int>(bond_timeout_.count()));
-      reset(true);  // hard reset to transition all still active down
+      reset(false);  // hard reset to transition all still active down
       // if a server crashed, it won't get cleared due to failed transition, clear manually
       bond_map_.clear();
 


### PR DESCRIPTION
Disable hard reset for the lifecycle manager in case of crash of a managed node. This way we will get error into the diagnostics if a server has crashed.
