### PR TITLE
Backport non-circular footprint search fix from upstream

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/collision_checker.hpp
@@ -127,7 +127,7 @@ protected:
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   std::vector<nav2_costmap_2d::Footprint> oriented_footprints_;
   nav2_costmap_2d::Footprint unoriented_footprint_;
-  float footprint_cost_;
+  float center_cost_;
   bool footprint_is_radius_;
   std::vector<float> angles_;
   float possible_inscribed_cost_{-1};

--- a/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
@@ -432,14 +432,6 @@ public:
     const unsigned int & goal_x, const unsigned int & goal_y);
 
   /**
-   * @brief Using the inflation layer, find the footprint's adjusted cost
-   * if the robot is non-circular
-   * @param cost Cost to adjust
-   * @return float Cost adjusted
-   */
-  static float adjustedFootprintCost(const float & cost);
-
-  /**
    * @brief Retrieve all valid neighbors of a node.
    * @param validity_checker Functor for state validity checking
    * @param collision_checker Collision checker to use
@@ -471,7 +463,6 @@ public:
 
   static nav2_costmap_2d::Costmap2D * sampled_costmap;
   static std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros;
-  static std::shared_ptr<nav2_costmap_2d::InflationLayer> inflation_layer;
   static CostmapDownsampler downsampler;
   // Dubin / Reeds-Shepp lookup and size for dereferencing
   static LookupTable dist_heuristic_lookup_table;

--- a/nav2_smac_planner/src/collision_checker.cpp
+++ b/nav2_smac_planner/src/collision_checker.cpp
@@ -149,7 +149,7 @@ bool GridCollisionChecker::inCollision(
       current_footprint.push_back(new_pt);
     }
 
-    footprint_cost = static_cast<float>(footprintCost(current_footprint));
+    float footprint_cost = static_cast<float>(footprintCost(current_footprint));
 
     if (footprint_cost == UNKNOWN && traverse_unknown) {
       return false;

--- a/nav2_smac_planner/src/collision_checker.cpp
+++ b/nav2_smac_planner/src/collision_checker.cpp
@@ -104,16 +104,13 @@ bool GridCollisionChecker::inCollision(
   }
 
   // Assumes setFootprint already set
-  double wx, wy;
-  costmap_->mapToWorld(static_cast<double>(x), static_cast<double>(y), wx, wy);
+  center_cost_ = static_cast<float>(costmap_->getCost(
+    static_cast<unsigned int>(x + 0.5f), static_cast<unsigned int>(y + 0.5f)));
 
   if (!footprint_is_radius_) {
     // if footprint, then we check for the footprint's points, but first see
     // if the robot is even potentially in an inscribed collision
-    footprint_cost_ = static_cast<float>(costmap_->getCost(
-        static_cast<unsigned int>(x + 0.5), static_cast<unsigned int>(y + 0.5)));
-
-    if (footprint_cost_ < possible_inscribed_cost_) {
+    if (center_cost_ < possible_inscribed_cost_) {
       if (possible_inscribed_cost_ > 0) {
         return false;
       } else {
@@ -129,17 +126,19 @@ bool GridCollisionChecker::inCollision(
 
     // If its inscribed, in collision, or unknown in the middle,
     // no need to even check the footprint, its invalid
-    if (footprint_cost_ == UNKNOWN && !traverse_unknown) {
+    if (center_cost_ == UNKNOWN && !traverse_unknown) {
       return true;
     }
 
-    if (footprint_cost_ == INSCRIBED || footprint_cost_ == OCCUPIED) {
+    if (center_cost_ == INSCRIBED || center_cost_ == OCCUPIED) {
       return true;
     }
 
     // if possible inscribed, need to check actual footprint pose.
     // Use precomputed oriented footprints are done on initialization,
     // offset by translation value to collision check
+    double wx, wy;
+    costmap_->mapToWorld(static_cast<double>(x), static_cast<double>(y), wx, wy);
     geometry_msgs::msg::Point new_pt;
     const nav2_costmap_2d::Footprint & oriented_footprint = oriented_footprints_[angle_bin];
     nav2_costmap_2d::Footprint current_footprint;
@@ -150,25 +149,22 @@ bool GridCollisionChecker::inCollision(
       current_footprint.push_back(new_pt);
     }
 
-    footprint_cost_ = static_cast<float>(footprintCost(current_footprint));
+    footprint_cost = static_cast<float>(footprintCost(current_footprint));
 
-    if (footprint_cost_ == UNKNOWN && traverse_unknown) {
+    if (footprint_cost == UNKNOWN && traverse_unknown) {
       return false;
     }
 
     // if occupied or unknown and not to traverse unknown space
-    return footprint_cost_ >= OCCUPIED;
+    return footprint_cost >= OCCUPIED;
   } else {
     // if radius, then we can check the center of the cost assuming inflation is used
-    footprint_cost_ = static_cast<float>(costmap_->getCost(
-        static_cast<unsigned int>(x + 0.5), static_cast<unsigned int>(y + 0.5)));
-
-    if (footprint_cost_ == UNKNOWN && traverse_unknown) {
+    if (center_cost_ == UNKNOWN && traverse_unknown) {
       return false;
     }
 
     // if occupied or unknown and not to traverse unknown space
-    return footprint_cost_ >= INSCRIBED;
+    return center_cost_ >= INSCRIBED;
   }
 }
 
@@ -176,19 +172,19 @@ bool GridCollisionChecker::inCollision(
   const unsigned int & i,
   const bool & traverse_unknown)
 {
-  footprint_cost_ = costmap_->getCost(i);
-  if (footprint_cost_ == UNKNOWN && traverse_unknown) {
+  center_cost_ = costmap_->getCost(i);
+  if (center_cost_ == UNKNOWN && traverse_unknown) {
     return false;
   }
 
   // if occupied or unknown and not to traverse unknown space
-  return footprint_cost_ >= INSCRIBED;
+  return center_cost_ >= INSCRIBED;
 }
 
 float GridCollisionChecker::getCost()
 {
   // Assumes inCollision called prior
-  return static_cast<float>(footprint_cost_);
+  return static_cast<float>(center_cost_);
 }
 
 bool GridCollisionChecker::outsideRange(const unsigned int & max, const float & value)

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -42,7 +42,6 @@ float NodeHybrid::size_lookup = 25;
 LookupTable NodeHybrid::dist_heuristic_lookup_table;
 nav2_costmap_2d::Costmap2D * NodeHybrid::sampled_costmap = nullptr;
 std::shared_ptr<nav2_costmap_2d::Costmap2DROS> NodeHybrid::costmap_ros = nullptr;
-std::shared_ptr<nav2_costmap_2d::InflationLayer> NodeHybrid::inflation_layer = nullptr;
 
 CostmapDownsampler NodeHybrid::downsampler;
 ObstacleHeuristicQueue NodeHybrid::obstacle_heuristic_queue;
@@ -488,7 +487,6 @@ void NodeHybrid::resetObstacleHeuristic(
   // erosion of path quality after even modest smoothing. The error would be no more
   // than 0.05 * normalized cost. Since this is just a search prior, there's no loss in generality
   costmap_ros = costmap_ros_i;
-  inflation_layer = nav2_costmap_2d::InflationLayer::getInflationLayer(costmap_ros);
   sampled_costmap = costmap_ros->getCostmap();
   if (motion_table.downsample_obstacle_heuristic) {
     std::weak_ptr<nav2_util::LifecycleNode> ptr;
@@ -533,29 +531,6 @@ void NodeHybrid::resetObstacleHeuristic(
   obstacle_heuristic_lookup_table[goal_index] = -0.00001f;
 }
 
-float NodeHybrid::adjustedFootprintCost(const float & cost)
-{
-  if (!inflation_layer) {
-    return cost;
-  }
-
-  const auto layered_costmap = costmap_ros->getLayeredCostmap();
-  const float scale_factor = inflation_layer->getCostScalingFactor();
-  const float min_radius = layered_costmap->getInscribedRadius();
-  float dist_to_obj = (scale_factor * min_radius - log(cost) + log(253.0f)) / scale_factor;
-
-  // Subtract minimum radius for edge cost
-  dist_to_obj -= min_radius;
-  if (dist_to_obj < 0.0f) {
-    dist_to_obj = 0.0f;
-  }
-
-  // Compute cost at this value
-  return static_cast<float>(
-    inflation_layer->computeCost(dist_to_obj / layered_costmap->getCostmap()->getResolution()));
-}
-
-
 float NodeHybrid::getObstacleHeuristic(
   const Coordinates & node_coords,
   const Coordinates & goal_coords,
@@ -563,7 +538,6 @@ float NodeHybrid::getObstacleHeuristic(
 {
   // If already expanded, return the cost
   const unsigned int size_x = sampled_costmap->getSizeInCellsX();
-  const bool is_circular = costmap_ros->getUseRadius();
 
   // Divided by 2 due to downsampled costmap.
   unsigned int start_y, start_x;
@@ -634,13 +608,7 @@ float NodeHybrid::getObstacleHeuristic(
       if (new_idx < size_x * size_y) {
         cost = static_cast<float>(sampled_costmap->getCost(new_idx));
 
-        if (!is_circular) {
-          // Adjust cost value if using SE2 footprint checks
-          cost = adjustedFootprintCost(cost);
-          if (cost >= OCCUPIED) {
-            continue;
-          }
-        } else if (cost >= INSCRIBED) {
+        if (cost >= INSCRIBED) {
           continue;
         }
 

--- a/nav2_smac_planner/test/test_collision_checker.cpp
+++ b/nav2_smac_planner/test/test_collision_checker.cpp
@@ -153,17 +153,22 @@ TEST(collision_footprint, test_footprint_at_pose_with_movement)
   nav2_smac_planner::GridCollisionChecker collision_checker(costmap_ros, 72, node);
   collision_checker.setFootprint(footprint, false /*use footprint*/, 0.0);
 
-  collision_checker.inCollision(50, 50, 0.0, false);
+  EXPECT_FALSE(collision_checker.inCollision(50, 50, 0.0, false));
   float cost = collision_checker.getCost();
   EXPECT_NEAR(cost, 128.0, 0.001);
 
-  collision_checker.inCollision(50, 49, 0.0, false);
+  EXPECT_TRUE(collision_checker.inCollision(50, 49, 0.0, false));
   float up_value = collision_checker.getCost();
-  EXPECT_NEAR(up_value, 254.0, 0.001);
+  EXPECT_NEAR(up_value, 128.0, 0.001);  // center cost
 
-  collision_checker.inCollision(50, 52, 0.0, false);
+  EXPECT_TRUE(collision_checker.inCollision(50, 52, 0.0, false));
   float down_value = collision_checker.getCost();
-  EXPECT_NEAR(down_value, 254.0, 0.001);
+  EXPECT_NEAR(down_value, 128.0, 0.001);  // center cost
+
+  EXPECT_TRUE(collision_checker.inCollision(11, 11, 0.0, false));
+  float other_value = collision_checker.getCost();
+  EXPECT_NEAR(other_value, 254.0, 0.001);  // center cost
+
   delete costmap_;
 }
 
@@ -200,16 +205,21 @@ TEST(collision_footprint, test_point_and_line_cost)
   nav2_smac_planner::GridCollisionChecker collision_checker(costmap_ros, 72, node);
   collision_checker.setFootprint(footprint, false /*use footprint*/, 0.0);
 
-  collision_checker.inCollision(50, 50, 0.0, false);
+  EXPECT_FALSE(collision_checker.inCollision(50, 50, 0.0, false));
   float value = collision_checker.getCost();
   EXPECT_NEAR(value, 128.0, 0.001);
 
-  collision_checker.inCollision(49, 50, 0.0, false);
+  EXPECT_TRUE(collision_checker.inCollision(49, 50, 0.0, false));
   float left_value = collision_checker.getCost();
-  EXPECT_NEAR(left_value, 254.0, 0.001);
+  EXPECT_NEAR(left_value, 128.0, 0.001);
 
-  collision_checker.inCollision(52, 50, 0.0, false);
+  EXPECT_TRUE(collision_checker.inCollision(52, 50, 0.0, false));
   float right_value = collision_checker.getCost();
-  EXPECT_NEAR(right_value, 254.0, 0.001);
+  EXPECT_NEAR(right_value, 128.0, 0.001);  // center cost
+
+  EXPECT_TRUE(collision_checker.inCollision(39, 60, 0.0, false));
+  float other_value = collision_checker.getCost();
+  EXPECT_NEAR(other_value, 254.0, 0.001);  // center cost
+
   delete costmap_;
 }


### PR DESCRIPTION
Including the SmacHybrid planner's fix for non-circular footprints (https://github.com/ros-navigation/navigation2/pull/4851) into our branch.